### PR TITLE
Fix reconnects

### DIFF
--- a/hm-rpc.js
+++ b/hm-rpc.js
@@ -1463,15 +1463,15 @@ function connect(isFirst) {
         clearInterval(eventInterval);
         eventInterval = null;
     }
+    
+    if (isFirst) sendInit();
 
-    // if not bin rpc
-    if (!rpcClient.connected) {
-        if (!connInterval) {
-            adapter.log.debug('start connecting interval');
-            connInterval = setInterval(function () {
-                sendInit();
-            }, adapter.config.reconnectInterval * 1000);
-        }
+    //Peridically try to reconnect
+    if (!connInterval) {
+        adapter.log.debug('start connecting interval');
+        connInterval = setInterval(function () {
+            sendInit();
+        }, adapter.config.reconnectInterval * 1000);
     }
 }
 

--- a/hm-rpc.js
+++ b/hm-rpc.js
@@ -1464,10 +1464,8 @@ function connect(isFirst) {
         eventInterval = null;
     }
 
-    if (isFirst) sendInit();
-
     // if not bin rpc
-    if (!rpcClient.connect) {
+    if (!rpcClient.connected) {
         if (!connInterval) {
             adapter.log.debug('start connecting interval');
             connInterval = setInterval(function () {


### PR DESCRIPTION
Reconnects were not working if the CCU initially not available: connInterval was not getting set
Reconnects were not working afterwards either due to a typo: rpcClient.connect -> rpcClient.connected