### PR TITLE
Update hm-rpc.js

### DIFF
--- a/hm-rpc.js
+++ b/hm-rpc.js
@@ -1407,7 +1407,7 @@ function updateConnection() {
     }
 
     // CUxD does not support ping
-    if (!eventInterval && adapter.config.daemon !== 'CUxD') {
+    if (!eventInterval) {
         adapter.log.debug('start ping interval');
         eventInterval = setInterval(keepAlive, adapter.config.checkInitInterval * 1000 / 2);
     }


### PR DESCRIPTION
CUxD 2.1.0 unterstützt jetzt die BINRPC Ping-Methode [forum](https://homematic-forum.de/forum/viewtopic.php?f=37&t=15298).
Damit kann das für CUxD wieder aktiviert werden. (#73)