### PR TITLE
Added meta-information for HmIP-WRC6

### DIFF
--- a/io-package.json
+++ b/io-package.json
@@ -23836,6 +23836,143 @@
                     "CONTROL": "MOTIONDETECTOR_TRANSCEIVER.MOTION_DETECTION_ACTIVE"
                 }
             }
+        },
+        {
+            "_id": "hm-rpc.meta.VALUES.HmIP-WRC6.MAINTENANCE.1",
+            "type": "meta",
+            "meta": {
+                "adapter": "hm-rpc",
+                "type": "paramsetDescription"
+            },
+            "common": {},
+            "native": {
+                "CONFIG_PENDING": {
+                    "MIN": false,
+                    "OPERATIONS": 5,
+                    "MAX": true,
+                    "FLAGS": 9,
+                    "ID": "CONFIG_PENDING",
+                    "TYPE": "BOOL",
+                    "DEFAULT": false
+                },
+                "DUTY_CYCLE": {
+                    "MIN": false,
+                    "OPERATIONS": 5,
+                    "MAX": true,
+                    "FLAGS": 1,
+                    "ID": "DUTY_CYCLE",
+                    "TYPE": "BOOL",
+                    "DEFAULT": false
+                },
+                "LOW_BAT": {
+                    "MIN": false,
+                    "OPERATIONS": 5,
+                    "MAX": true,
+                    "FLAGS": 9,
+                    "ID": "LOW_BAT",
+                    "TYPE": "BOOL",
+                    "DEFAULT": false
+                },
+                "INSTALL_TEST": {
+                    "MIN": false,
+                    "OPERATIONS": 3,
+                    "MAX": true,
+                    "FLAGS": 2,
+                    "ID": "INSTALL_TEST",
+                    "TYPE": "BOOL",
+                    "DEFAULT": false
+                },
+                "UNREACH": {
+                    "MIN": false,
+                    "OPERATIONS": 5,
+                    "MAX": true,
+                    "FLAGS": 25,
+                    "ID": "UNREACH",
+                    "TYPE": "BOOL",
+                    "DEFAULT": false
+                },
+                "OPERATING_VOLTAGE_STATUS": {
+                    "MIN": "NORMAL",
+                    "OPERATIONS": 5,
+                    "MAX": "OVERFLOW",
+                    "FLAGS": 1,
+                    "ID": "OPERATING_VOLTAGE_STATUS",
+                    "TYPE": "ENUM",
+                    "DEFAULT": "NORMAL",
+                    "VALUE_LIST": [
+                        "NORMAL",
+                        "UNKNOWN",
+                        "OVERFLOW"
+                    ]
+                },
+                "RSSI_DEVICE": {
+                    "MIN": -128,
+                    "OPERATIONS": 5,
+                    "MAX": 127,
+                    "FLAGS": 1,
+                    "ID": "RSSI_DEVICE",
+                    "TYPE": "INTEGER",
+                    "DEFAULT": 0
+                },
+                "OPERATING_VOLTAGE": {
+                    "MIN": 0,
+                    "OPERATIONS": 5,
+                    "MAX": 25.2,
+                    "FLAGS": 1,
+                    "ID": "OPERATING_VOLTAGE",
+                    "TYPE": "FLOAT",
+                    "DEFAULT": 0
+                },
+                "RSSI_PEER": {
+                    "MIN": -128,
+                    "OPERATIONS": 5,
+                    "MAX": 127,
+                    "FLAGS": 1,
+                    "ID": "RSSI_PEER",
+                    "TYPE": "INTEGER",
+                    "DEFAULT": 0
+                },
+                "UPDATE_PENDING": {
+                    "MIN": false,
+                    "OPERATIONS": 5,
+                    "MAX": true,
+                    "FLAGS": 9,
+                    "ID": "UPDATE_PENDING",
+                    "TYPE": "BOOL",
+                    "DEFAULT": false
+                }
+            }
+        },
+        {
+            "_id": "hm-rpc.meta.VALUES.HmIP-WRC6.KEY_TRANSCEIVER.1",
+            "type": "meta",
+            "meta": {
+                "adapter": "hm-rpc",
+                "type": "paramsetDescription"
+            },
+            "common": {},
+            "native": {
+                "PRESS_SHORT": {
+                    "MIN": false,
+                    "OPERATIONS": 4,
+                    "MAX": true,
+                    "FLAGS": 1,
+                    "ID": "PRESS_SHORT",
+                    "TYPE": "ACTION",
+                    "DEFAULT": false,
+                    "CONTROL": "BUTTON_NO_FUNCTION.SHORT"
+                },
+                "PRESS_LONG": {
+                    "MIN": false,
+                    "OPERATIONS": 4,
+                    "MAX": true,
+                    "FLAGS": 1,
+                    "ID": "PRESS_LONG",
+                    "TYPE": "ACTION",
+                    "DEFAULT": false,
+                    "CONTROL": "BUTTON_NO_FUNCTION.LONG"
+                }
+            }
         }
     ],
     "instanceObjects": [


### PR DESCRIPTION
The following information was shown in my log files:

```
2019-01-04 22:51:30.441 - warn: hm-rpc.0 Send this info to developer: _id: "hm-rpc.meta.VALUES.HmIP-WRC6.MAINTENANCE.1"
2019-01-04 22:51:30.441 - warn: hm-rpc.0 Send this info to developer: {"type":"meta","meta":{"adapter":"hm-rpc","type":"paramsetDescription"},"common":{},"native":{"CONFIG_PENDING":{"MIN":false,"OPERATIONS":5,"MAX":true,"FLAGS":9,"ID":"CONFIG_PENDING","TYPE":"BOOL","DEFAULT":false},"DUTY_CYCLE":{"MIN":false,"OPERATIONS":5,"MAX":true,"FLAGS":1,"ID":"DUTY_CYCLE","TYPE":"BOOL","DEFAULT":false},"LOW_BAT":{"MIN":false,"OPERATIONS":5,"MAX":true,"FLAGS":9,"ID":"LOW_BAT","TYPE":"BOOL","DEFAULT":false},"INSTALL_TEST":{"MIN":false,"OPERATIONS":3,"MAX":true,"FLAGS":2,"ID":"INSTALL_TEST","TYPE":"BOOL","DEFAULT":false},"UNREACH":{"MIN":false,"OPERATIONS":5,"MAX":true,"FLAGS":25,"ID":"UNREACH","TYPE":"BOOL","DEFAULT":false},"OPERATING_VOLTAGE_STATUS":{"MIN":"NORMAL","OPERATIONS":5,"MAX":"OVERFLOW","FLAGS":1,"ID":"OPERATING_VOLTAGE_STATUS","TYPE":"ENUM","DEFAULT":"NORMAL","VALUE_LIST":["NORMAL","UNKNOWN","OVERFLOW"]},"RSSI_DEVICE":{"MIN":-128,"OPERATIONS":5,"MAX":127,"FLAGS":1,"ID":"RSSI_DEVICE","TYPE":"INTEGER","DEFAULT":0},"OPERATING_VOLTAGE":{"MIN":0,"OPERATIONS":5,"MAX":25.2,"FLAGS":1,"ID":"OPERATING_VOLTAGE","TYPE":"FLOAT","DEFAULT":0},"RSSI_PEER":{"MIN":-128,"OPERATIONS":5,"MAX":127,"FLAGS":1,"ID":"RSSI_PEER","TYPE":"INTEGER","DEFAULT":0},"UPDATE_PENDING":{"MIN":false,"OPERATIONS":5,"MAX":true,"FLAGS":9,"ID":"UPDATE_PENDING","TYPE":"BOOL","DEFAULT":false}}}

2019-01-04 22:51:30.493 - warn: hm-rpc.0 Send this info to developer: _id: "hm-rpc.meta.VALUES.HmIP-WRC6.KEY_TRANSCEIVER.1"
2019-01-04 22:51:30.493 - warn: hm-rpc.0 Send this info to developer: {"type":"meta","meta":{"adapter":"hm-rpc","type":"paramsetDescription"},"common":{},"native":{"PRESS_SHORT":{"MIN":false,"OPERATIONS":4,"MAX":true,"FLAGS":1,"ID":"PRESS_SHORT","TYPE":"ACTION","DEFAULT":false,"CONTROL":"BUTTON_NO_FUNCTION.SHORT"},"PRESS_LONG":{"MIN":false,"OPERATIONS":4,"MAX":true,"FLAGS":1,"ID":"PRESS_LONG","TYPE":"ACTION","DEFAULT":false,"CONTROL":"BUTTON_NO_FUNCTION.LONG"}}}
```

The patch implements the missing meta-information for the HmIP-WRC6 device. I tested it locally, the log does not show the information anymore when using the patched io-package.json.