### PR TITLE
Logo image link added for HmIP-PCBS

### DIFF
--- a/lib/images.js
+++ b/lib/images.js
@@ -325,5 +325,6 @@ module.exports =  {
     'HmIP-DRDI3':               '204_hmip-drdi3_thumb.png',
     'HmIP-DRSI4':               '205_hmip-drsi4_thumb.png',
     'HmIP-DRBLI4':              '206_hmip-drbli4_thumb.png',
-    'HmIP-DSD-PCB':             '208_hmip-dsd-pcb_thumb.png'
+    'HmIP-DSD-PCB':             '208_hmip-dsd-pcb_thumb.png',
+    'HmIP-PCBS':                '139_hm-lc-sw1-pcb_thumb.png'
 };


### PR DESCRIPTION
- added missing logo file link for HmIP-PCBS which also uses the "139_hm-lc-sw1-pcb_thumb.png" image on a CCU3.