### PR TITLE
Added icon for the HmIP-HAP access point

### DIFF
--- a/lib/images.js
+++ b/lib/images.js
@@ -80,6 +80,7 @@ module.exports =  {
     'HmIP-STV': '201_hmip-stv_thumb.png',
     'HMW-Sys-PS7-DR': '36_hmw-sys-ps7-dr_thumb.png',
     'HmIP-CCU3': 'CCU3_thumb.png',
+    'HmIP-HAP': 'CCU3_thumb.png',
     'HMW-Sen-SC-12-DR': '56_hmw-sen-sc-12-dr_thumb.png',
     'HmIP-DRSI4': '205_hmip-drsi4_thumb.png',
     'HM-Dis-WM55': '97_hm-dis-wm55_thumb.png',


### PR DESCRIPTION
Hi,

with CCU firmware 3.53.27.* Homematic IP access points (HmIP-HAP) can be configured as a LAN-Gateway for Homematic IP. Such HmIP-HAPs already show up in ioBroker but currently possess no icon. RaspberryMatic uses the same icon for the HmIP-HAP as for the CCU itself. So I used that already existing icon and created the missing entry in the images.js table. Here on my system the object tree shows the correct icon now.

Regards,
Florian