### PR TITLE
fixed the VirtualDevices min/max/default assignment.

### DIFF
--- a/main.js
+++ b/main.js
@@ -1259,13 +1259,13 @@ async function addParamsetObjects(channel, paramset) {
 
         // sometimes min/max/def is string on hmip meta in combination with value_list
         if (paramset[key].VALUE_LIST) {
-            if (typeof paramset[key].MIN === 'string') {
+            if (typeof paramset[key].MIN === 'string' && paramset[key].VALUE_LIST.indexOf(paramset[key].MIN) !== -1) {
                 obj.common.min = paramset[key].VALUE_LIST.indexOf(paramset[key].MIN);
             }
-            if (typeof paramset[key].MAX === 'string') {
+            if (typeof paramset[key].MAX === 'string' && paramset[key].VALUE_LIST.indexOf(paramset[key].MIN) !== -1) {
                 obj.common.max = paramset[key].VALUE_LIST.indexOf(paramset[key].MAX);
             }
-            if (typeof paramset[key].DEFAULT === 'string') {
+            if (typeof paramset[key].DEFAULT === 'string') && paramset[key].VALUE_LIST.indexOf(paramset[key].DEFAULT) !== -1) {
                 obj.common.def = paramset[key].VALUE_LIST.indexOf(paramset[key].DEFAULT);
             }
         }


### PR DESCRIPTION
In case a string based value list match doesn't work out (indexOf() === -1) we take the
original value instead of using -1 which indexOf() returns.
This refs #332.